### PR TITLE
add BLOCK_GAS_LIMIT

### DIFF
--- a/ethereum/config.py
+++ b/ethereum/config.py
@@ -27,6 +27,7 @@ default_config = dict(
     #                   (block.gas_used * 6 / 5) / 1024
     GASLIMIT_EMA_FACTOR=1024,
     GASLIMIT_ADJMAX_FACTOR=1024,
+    BLOCK_GAS_LIMIT=4712388,
     BLKLIM_FACTOR_NOM=3,
     BLKLIM_FACTOR_DEN=2,
     # Network ID

--- a/ethereum/genesis_helpers.py
+++ b/ethereum/genesis_helpers.py
@@ -107,11 +107,12 @@ def mk_genesis_block(env, **kwargs):
 
 
 def mk_basic_state(alloc, header=None, env=None, executing_on_head=False):
-    state = State(env=env or Env(), executing_on_head=executing_on_head)
+    env = env or Env()
+    state = State(env=env, executing_on_head=executing_on_head)
     if not header:
         header = {
-            "number": 0, "gas_limit": 4712388, "gas_used": 0,
-            "timestamp": 1467446877, "difficulty": 1,
+            "number": 0, "gas_limit": env.config['BLOCK_GAS_LIMIT'],
+            "gas_used": 0, "timestamp": 1467446877, "difficulty": 1,
             "uncles_hash": '0x'+encode_hex(BLANK_UNCLES_HASH)
         }
     h = BlockHeader(number=parse_as_int(header['number']),

--- a/ethereum/pow/chain.py
+++ b/ethereum/pow/chain.py
@@ -60,7 +60,7 @@ class Chain(object):
             print('Initializing chain from new state based on alloc')
             self.state = mk_basic_state(genesis, {
                 "number": kwargs.get('number', 0),
-                "gas_limit": kwargs.get('gas_limit', 4712388),
+                "gas_limit": kwargs.get('gas_limit', self.env.config['BLOCK_GAS_LIMIT']),
                 "gas_used": kwargs.get('gas_used', 0),
                 "timestamp": kwargs.get('timestamp', 1467446877),
                 "difficulty": kwargs.get('difficulty', 2**25),


### PR DESCRIPTION
With this change the following code works:

```python
from ethereum.tools import tester as tester
from ethereum.abi import ContractTranslator
from ethereum.tools.tester import ABIContract
from ethereum import utils as u
from ethereum.config import config_metropolis, Env

config_metropolis['BLOCK_GAS_LIMIT'] = 2**60

chain = tester.Chain(env=Env(config=config_metropolis))

chain.block.timestamp = 1

chain.contract('src/trading/orders.se', language='serpent', startgas=long(6 * 10**6))
chain.contract('src/trading/orders.se', language='serpent', startgas=long(6 * 10**6))

chain.mine()
```

I threw this on PyPi so you can `pip uninstall ethereum; pip install ethereum-augur-temp` to test.